### PR TITLE
fix package version conflict with @byzanteam/eslint-config

### DIFF
--- a/.changeset/long-rivers-appear.md
+++ b/.changeset/long-rivers-appear.md
@@ -1,0 +1,5 @@
+---
+"@byzanteam/eslint-config-vue": major
+---
+
+Fix version conflict with @byzanteam/eslint-config

--- a/packages/eslint-vue/package.json
+++ b/packages/eslint-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@byzanteam/eslint-config-vue",
   "description": "Byzanteam sharable ESLint configuration for vue.",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "main": "index.js",
   "repository": "git@github.com:byzanteam/jet-linter/packages/eslint-vue",
   "publishConfig": {


### PR DESCRIPTION
与之前的 lint 包冲突了 `https://github.com/Byzanteam/eslint-config`

eslint-config 这个 repo 可以 Archive 了，未来就维护 jet-linter 项目？