### PR TITLE
fix: remove tsconfig exports alias

### DIFF
--- a/.changeset/wild-kangaroos-joke.md
+++ b/.changeset/wild-kangaroos-joke.md
@@ -1,0 +1,5 @@
+---
+'@byzanteam/tsconfig': patch
+---
+
+remove exports alias

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -12,27 +12,11 @@ _use base config_
 
 ```jsonc
 {
-  "extends": "@byzanteam/tsconfig"
-}
-```
-
-or
-
-```jsonc
-{
   "extends": "@byzanteam/tsconfig/tsconfig.base.json"
 }
 ```
 
 _use vue config_
-
-```jsonc
-{
-  "extends": "@byzanteam/tsconfig/vue"
-}
-```
-
-or
 
 ```jsonc
 {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,10 +3,6 @@
   "version": "2.0.2",
   "license": "MIT",
   "main": "tsconfig.base.json",
-  "exports": {
-    ".": "./tsconfig.base.json",
-    "./vue": "./tsconfig.vue.json"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
npm 拉下的包 vscode 插件可以找到配置，但是 vue-tsc 没法通过包的导出文件找到配置导致打包时出错，只能移除 exports ，通过文件路径导入