### PR TITLE
fix: tsconfig-vue remove exactOptionalPropertyTypes

### DIFF
--- a/.changeset/four-cameras-pull.md
+++ b/.changeset/four-cameras-pull.md
@@ -1,0 +1,5 @@
+---
+'@byzanteam/tsconfig': patch
+---
+
+tsconfig-vue remove exactOptionalPropertyTypes

--- a/packages/tsconfig/tsconfig.vue.json
+++ b/packages/tsconfig/tsconfig.vue.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["ESNext", "DOM"]
+    "lib": ["ESNext", "DOM"],
+    "exactOptionalPropertyTypes": false
   }
 }


### PR DESCRIPTION
这个选项开启后会影响`withDefaults`设置的默认值在`template`中类型的推断