### PR TITLE
fix: eslint-vue parser change

### DIFF
--- a/.changeset/itchy-laws-confess.md
+++ b/.changeset/itchy-laws-confess.md
@@ -1,0 +1,6 @@
+---
+'@byzanteam/eslint-config-vue-ts': patch
+'@byzanteam/eslint-config-ts': patch
+---
+
+add type-checked rules and fix type-checked error when use vue

--- a/packages/eslint-ts/index.js
+++ b/packages/eslint-ts/index.js
@@ -8,6 +8,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:import/errors',
     'plugin:prettier/recommended',
   ],

--- a/packages/eslint-vue-ts/index.js
+++ b/packages/eslint-vue-ts/index.js
@@ -1,11 +1,14 @@
 module.exports = {
   extends: [
-    '@vue/eslint-config-typescript/recommended',
     '@vue/eslint-config-prettier',
     '@byzanteam/eslint-config-ts',
+    '@vue/eslint-config-typescript/recommended',
     'plugin:vue/vue3-essential',
   ],
   env: { 'vue/setup-compiler-macros': true },
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+  },
   rules: {
     'vue/no-unused-properties': 'error',
     'vue/require-name-property': 'error',

--- a/packages/eslint-vue-ts/package.json
+++ b/packages/eslint-vue-ts/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@byzanteam/eslint-config-ts": "workspace:*",
+    "@typescript-eslint/parser": "5.62.0",
     "@vue/eslint-config-prettier": "^7.1.0",
     "@vue/eslint-config-typescript": "^11.0.3",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@rushstack/eslint-patch':
         specifier: ^1.2.0
         version: 1.2.0
+      '@typescript-eslint/parser':
+        specifier: 5.62.0
+        version: 5.62.0(eslint@8.44.0)(typescript@5.0.2)
       '@vue/eslint-config-prettier':
         specifier: ^7.1.0
         version: 7.1.0(eslint@8.44.0)(prettier@2.8.8)
@@ -111,7 +114,7 @@ importers:
         specifier: ^8.44.0
         version: 8.44.0
       prettier:
-        specifier: ^2.8.8
+        specifier: ^2.8.5
         version: 2.8.8
       typescript:
         specifier: ^5.0.2
@@ -171,7 +174,7 @@ packages:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.7.1
+      prettier: 2.8.8
       resolve-from: 5.0.0
       semver: 5.7.1
     dev: true
@@ -356,7 +359,7 @@ packages:
       '@changesets/types': 5.2.0
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.7.1
+      prettier: 2.8.8
     dev: true
 
   /@commitlint/cli@17.4.2:


### PR DESCRIPTION
eslint-config-ts 中使用 @typescript-eslint/parser 做解析器，但是 vue 文件使用的是 vue-eslinnt-parser，导致在 vue 文件中需要类型信息的规则（如`@typescript-eslint/switch-exhaustiveness-check`）会报错，通过设置 `parserOptions.parser` 解决这个问题