### PR TITLE
fix: typescript-eslint recommended error

### DIFF
--- a/.changeset/moody-jeans-fix.md
+++ b/.changeset/moody-jeans-fix.md
@@ -1,0 +1,6 @@
+---
+'@byzanteam/eslint-config-ts': patch
+'@byzanteam/eslint-config-vue-ts': patch
+---
+
+lint extends type-checking error

--- a/packages/eslint-ts/index.js
+++ b/packages/eslint-ts/index.js
@@ -8,7 +8,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:import/errors',
     'plugin:prettier/recommended',
   ],


### PR DESCRIPTION
那个 recommended 在 `@typescript-eslint/eslint-plugin` 6.x 后才有，暂时先不升级，因为`@vue/eslint-config-typescript`的依赖版本还未支持，lint 时会因为有多个版本产生冲突