### PR TITLE
fix: off some type-checked rule

### DIFF
--- a/.changeset/tasty-pugs-watch.md
+++ b/.changeset/tasty-pugs-watch.md
@@ -1,0 +1,6 @@
+---
+'@byzanteam/eslint-config-vue-ts': patch
+'@byzanteam/eslint-config-ts': patch
+---
+
+rule update

--- a/packages/eslint-ts/index.js
+++ b/packages/eslint-ts/index.js
@@ -34,6 +34,8 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
     'import/named': 'off',
     'import/order': [
       'error',

--- a/packages/eslint-vue-ts/index.js
+++ b/packages/eslint-vue-ts/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'vue/define-emits-declaration': ['error', 'type-based'],
     'vue/no-required-prop-with-default': 'error',
     'vue/attribute-hyphenation': 'error',
+    'vue/no-setup-props-destructure': 'warn',
   },
   settings: {
     'import/resolver': {

--- a/packages/eslint-vue-ts/index.js
+++ b/packages/eslint-vue-ts/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: [
     '@vue/eslint-config-prettier',
-    '@byzanteam/eslint-config-ts',
     '@vue/eslint-config-typescript/recommended',
+    '@byzanteam/eslint-config-ts',
     'plugin:vue/vue3-essential',
   ],
   env: { 'vue/setup-compiler-macros': true },


### PR DESCRIPTION
`@typescript-eslint/no-unsafe-argument` 这条规则限制传入函数的参数不能有 any ，但是如果参数的类型为含有泛型的类型，且泛型中含有 any（一般是做泛型参数的默认值），该规则仍然会报错
既然项目中已经存在 `no-explicit-any` 来限制 any 的出现，这条规则就主要会对一些非项目内代码进行报错，这样不如关闭该规则

```typescript
import { type Component, h } from 'vue'
import Icon from '~icons/xxx'

declare function renderIcon(icon: Component): Component 

renderIcon(Icon) // 因为 Icon 的类型为 FunctionalComponent<SVGAttributes, {}, any> 会导致报错
```